### PR TITLE
fix: allow partial releases when some platform builds fail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,8 @@ jobs:
     name: Release to RubyGems and GitHub
     needs: build
     runs-on: ubuntu-latest
+    # Run even if some builds failed (partial release)
+    if: always() && !cancelled() && needs.build.result != 'skipped'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -131,4 +133,6 @@ jobs:
           chmod 0600 ~/.gem/credentials
           gem signin
           mkdir tmp
-          for gem in pkg/*.gem; do gem push -V $gem; done
+          for gem in pkg/*.gem; do
+            gem push -V "$gem" || echo "Warning: Failed to push $gem"
+          done


### PR DESCRIPTION
## Summary

- Release job now runs even if some platform builds fail (partial release)
- Individual gem push failures don't block other gems
- GitHub releases will be created with successfully built gems

## Background

The v0.5.1 and v0.5.2 releases were not created because:

1. **v0.5.1**: Tag was never pushed to GitHub
2. **v0.5.2**: Release job was skipped because `aarch64-linux-musl` build failed

When any build in the matrix fails, the entire `build` job is marked as failed, which causes the `release` job to be skipped (since it has `needs: build` without `if: always()`).

## Fix

Added condition to release job:
```yaml
if: always() && !cancelled() && needs.build.result != 'skipped'
```

This allows the release to proceed with successfully built gems even when some platforms fail.

## Testing

After merging, manually trigger a release with `version_bump: skip` to create the missing v0.5.2 release.